### PR TITLE
RW dev analysis ntuplizer

### DIFF
--- a/Analysis/Ntuplizer/interface/TriggerAccepts.h
+++ b/Analysis/Ntuplizer/interface/TriggerAccepts.h
@@ -42,7 +42,7 @@ namespace analysis {
       class TriggerAccepts {
          public:
             TriggerAccepts();
-            TriggerAccepts(const edm::InputTag&, TTree*, const std::vector<std::string> &);
+            TriggerAccepts(const edm::InputTag&, TTree*, const std::vector<std::string> &, const bool & testmode = false);
            ~TriggerAccepts();
             void Fill(const edm::Event&);
             void Branches();
@@ -54,7 +54,11 @@ namespace analysis {
             edm::InputTag input_collection_;
             HLTConfigProvider hlt_config_;
             std::vector<std::string> paths_;
-            bool accept_[32];
+            std::vector<std::string> inpaths_;
+            bool accept_[1000];
+            
+            bool first_;
+            bool testmode_;
             
             TTree * tree_;
             


### PR DESCRIPTION
More trigger paths (up to 1000!) to be checked whether fired or not.
Introduced a TestMode option in the Ntuplizer EDANalyzer with which one can do out-of-normal things. Used in the TriggerAccepts to either check all paths or paths with common strings in the name.
TestMode needs to be used carefully. 
To do: Should put in the metadata whether ran on test mode or not.
