### PR TITLE
Addition of L1 and HLT prescale information in trigger results

### DIFF
--- a/Analysis/Ntuplizer/interface/TriggerAccepts.h
+++ b/Analysis/Ntuplizer/interface/TriggerAccepts.h
@@ -44,7 +44,7 @@ namespace analysis {
             TriggerAccepts();
             TriggerAccepts(const edm::InputTag&, TTree*, const std::vector<std::string> &, const bool & testmode = false);
            ~TriggerAccepts();
-            void Fill(const edm::Event&);
+            void Fill(const edm::Event & event, const edm::EventSetup & setup);
             void Branches();
             void LumiBlock(edm::LuminosityBlock const & , edm::EventSetup const& );
       
@@ -56,6 +56,8 @@ namespace analysis {
             std::vector<std::string> paths_;
             std::vector<std::string> inpaths_;
             bool accept_[1000];
+            int psl1_[1000];
+            int pshlt_[1000];
             
             bool first_;
             bool testmode_;

--- a/Analysis/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Analysis/Ntuplizer/plugins/Ntuplizer.cc
@@ -389,7 +389,7 @@ void Ntuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
       
       // trigger accecpts
       for ( auto & collection : triggeraccepts_collections_ )
-         collection -> Fill(event);
+         collection -> Fill(event, iSetup);
       
       // primary vertices
       for ( auto & collection : primaryvertices_collections_ )

--- a/Analysis/Ntuplizer/src/TriggerAccepts.cc
+++ b/Analysis/Ntuplizer/src/TriggerAccepts.cc
@@ -59,7 +59,7 @@ TriggerAccepts::~TriggerAccepts()
 //
 
 // ------------ method called for each event  ------------
-void TriggerAccepts::Fill(const edm::Event& event)
+void TriggerAccepts::Fill(const edm::Event& event, const edm::EventSetup & setup)
 {
    using namespace edm;
    
@@ -75,10 +75,12 @@ void TriggerAccepts::Fill(const edm::Event& event)
    {
       for (size_t i = 0; i < paths_.size() ; ++i )
       {
-         if ( hlt_config_.triggerName(j).find(paths_[i]) == 0 && triggers.accept(j) )
+         if ( hlt_config_.triggerName(j).find(paths_[i]) == 0 )
          {
-            accept_[i] = true;
-            break;
+            std::pair< int, int > ps = hlt_config_.prescaleValues (event, setup, hlt_config_.triggerName(j));
+            psl1_[i] = ps.first;
+            pshlt_[i] = ps.second;
+            if ( triggers.accept(j) ) accept_[i] = true;
          }
       }
    }
@@ -93,6 +95,8 @@ void TriggerAccepts::Branches()
    for (size_t i = 0; i < paths_.size() ; ++i )
    {
       tree_->Branch(paths_[i].c_str(), &accept_[i], (paths_[i]+"/O").c_str());
+      tree_->Branch(("psl1_"+paths_[i]).c_str(), &psl1_[i], ("psl1_"+paths_[i]+"/I").c_str());
+      tree_->Branch(("pshlt_"+paths_[i]).c_str(), &pshlt_[i], ("pshlt_"+paths_[i]+"/I").c_str());
    }
    // std::cout << "TriggerAccepts Branches ok" << std::endl;
 }
@@ -104,7 +108,7 @@ void TriggerAccepts::LumiBlock(edm::LuminosityBlock const & lumi, edm::EventSetu
    
    std::vector<std::string> names = hlt_config_.triggerNames();
    
-   if ( first_ )
+   if ( first_ )  // using this kind of resource to get the names from the configuration, when needed.
    {
       if ( ! testmode_ )
          paths_ = inpaths_;


### PR DESCRIPTION
The annoying part of this implementation is an error message coming from the HLTConfigProvider that cannot be suppressed. The error appears when an HLT path uses logical combinations of L1 seeds. When that happens the execution is not interrupted but loads os messages are issued for every event.
