### PR TITLE
Added GenFilteInfo data for weighted MC samples in GeneratorFilter

### DIFF
--- a/Analysis/Ntuplizer/interface/EventFilter.h
+++ b/Analysis/Ntuplizer/interface/EventFilter.h
@@ -43,6 +43,12 @@ namespace analysis {
          unsigned int filtered;
          double efficiency;
       };
+      
+      struct WeightedFilterResults {
+         double total;
+         double filtered;
+         double efficiency;
+      };
 
       template <typename T>
       class EventFilter {
@@ -53,6 +59,7 @@ namespace analysis {
             void SetCollections(const std::vector<edm::InputTag> &);
             void Increment(edm::LuminosityBlock const& );
             FilterResults Results();
+            WeightedFilterResults WeightedResults();
             TTree * Tree();
             void Fill();
       
@@ -61,6 +68,11 @@ namespace analysis {
             unsigned int    nTotal_;
             unsigned int    nFiltr_;
             double          efficiency_;
+            unsigned int    nTried_;
+            double          wTotal_;
+            double          wFiltr_;
+            double          wEfficiency_;
+            
             std::vector<edm::InputTag> collections_;
             
             // Output tree


### PR DESCRIPTION
Now the total and fitered number of events in weighted MC shows number of events
instead of sum of weights. The weights are in the new weight variables, namely,
weightsTotal, weightsFiltered and weightsEfficiency. In addition the number of tried
events is also added. Running on an entire file of a weighted MC sample the number
of events tried must be the same as the total of reconstructed events as long as no
event filter is used.
