### PR TITLE
Dev analysis ntuplizer 76 x

### DIFF
--- a/Analysis/Ntuplizer/BuildFile.xml
+++ b/Analysis/Ntuplizer/BuildFile.xml
@@ -13,6 +13,9 @@
 <use name="root"/>
 <use name="rootmath"/>
 <use name="boost" />
+<!--
+<Flags CPPDEFINES="CMSSWOLD" />
+-->
 <export>
   <lib name="1"/>
 </export>

--- a/Analysis/Ntuplizer/BuildFile.xml
+++ b/Analysis/Ntuplizer/BuildFile.xml
@@ -13,9 +13,6 @@
 <use name="root"/>
 <use name="rootmath"/>
 <use name="boost" />
-<!--
-<Flags CPPDEFINES="CMSSWOLD" />
--->
 <export>
   <lib name="1"/>
 </export>

--- a/Analysis/Ntuplizer/interface/TriggerAccepts.h
+++ b/Analysis/Ntuplizer/interface/TriggerAccepts.h
@@ -28,7 +28,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#ifndef CMSSWOLD        
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
+#endif            
 
 #include "TTree.h"
 

--- a/Analysis/Ntuplizer/interface/TriggerAccepts.h
+++ b/Analysis/Ntuplizer/interface/TriggerAccepts.h
@@ -1,3 +1,4 @@
+//#define CMSSWOLD
 #ifndef Analysis_Ntuplizer_TriggerAccepts_h
 #define Analysis_Ntuplizer_TriggerAccepts_h 1
 
@@ -29,7 +30,8 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#ifndef CMSSWOLD        
+
+#ifndef CMSSWOLD
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 #endif            
 

--- a/Analysis/Ntuplizer/interface/TriggerAccepts.h
+++ b/Analysis/Ntuplizer/interface/TriggerAccepts.h
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #ifndef CMSSWOLD        
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 #endif            

--- a/Analysis/Ntuplizer/interface/TriggerAccepts.h
+++ b/Analysis/Ntuplizer/interface/TriggerAccepts.h
@@ -28,7 +28,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 
 #include "TTree.h"
 
@@ -42,6 +42,9 @@ namespace analysis {
       class TriggerAccepts {
          public:
             TriggerAccepts();
+#ifndef CMSSWOLD        
+            TriggerAccepts(const edm::InputTag&, TTree*, const std::vector<std::string> &, const std::shared_ptr<HLTPrescaleProvider> hltPrescale , const bool & testmode = false);
+#endif            
             TriggerAccepts(const edm::InputTag&, TTree*, const std::vector<std::string> &, const bool & testmode = false);
            ~TriggerAccepts();
             void Fill(const edm::Event & event, const edm::EventSetup & setup);
@@ -53,6 +56,9 @@ namespace analysis {
             
             edm::InputTag input_collection_;
             HLTConfigProvider hlt_config_;
+#ifndef CMSSWOLD       
+            std::shared_ptr<HLTPrescaleProvider> hlt_prescale_;
+#endif            
             std::vector<std::string> paths_;
             std::vector<std::string> inpaths_;
             bool accept_[1000];


### PR DESCRIPTION
This request includes a possibility to compile the framework in both CMSSW_7_4_X (and previous) and CMSSW_7_5_X (and later) releases.
Intention was to have a plug&play solution, however after 3 days of unsuccessful attempts using macros, I ended up with a solution that requires the user to change a file before compiling the codes.
To compile in old release (7_4_X and earlier) edit the Analysis/Ntuplizer/interface/TriggerAccepts.h and uncomment the first line. For later releases, one has to do nothing.
