### PR TITLE
PileupInfo in EventInfo tree

### DIFF
--- a/Analysis/Ntuplizer/interface/EventInfo.h
+++ b/Analysis/Ntuplizer/interface/EventInfo.h
@@ -50,6 +50,8 @@ namespace analysis {
            ~EventInfo();
             void Fill(const edm::Event&);
             void Init();
+            void PileupInfo(const edm::InputTag&);
+            void ReadPileupInfo(const edm::Event&);
             TTree * Tree();
       
          private:
@@ -64,6 +66,12 @@ namespace analysis {
             
             // Output tree
             TTree * tree_;
+            
+            // PileupInfo
+            edm::InputTag puInfo_;
+            bool do_pu_;
+            int n_pu_;
+            float n_true_pu_;
             
       };
    }

--- a/Analysis/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Analysis/Ntuplizer/plugins/Ntuplizer.cc
@@ -368,8 +368,8 @@ void Ntuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
    // Event info
    eventinfo_ -> Fill(event);
    
-   if ( do_pileupinfo_ )
-      pileupinfo_ -> Fill(event);
+//    if ( do_pileupinfo_ )
+//       pileupinfo_ -> Fill(event);
 
    if ( is_mc_ )
    {
@@ -521,6 +521,8 @@ Ntuplizer::beginJob()
    
    // Event info tree
    eventinfo_ = pEventInfo (new EventInfo(eventsDir));
+   if ( do_pileupinfo_ )
+      eventinfo_ -> PileupInfo(config_.getParameter<edm::InputTag>("PileupInfo"));
    
     // Metadata 
    metadata_ = pMetadata (new Metadata(fs,is_mc_));
@@ -706,13 +708,13 @@ Ntuplizer::beginJob()
          if ( nCounters == 2 ) metadata_ -> SetEventFilter(eventCounters_);
       }
       // Pileup Info
-      if ( inputTag == "PileupInfo" && is_mc_ )
-      {
-         tree_[name] = eventsDir.make<TTree>(name.c_str(),fullname.c_str());
-         pileupinfo_ = pPileupInfo( new PileupInfo(collection, tree_[name]) );
-         pileupinfo_ -> Branches();
-
-      }
+//       if ( inputTag == "PileupInfo" && is_mc_ )
+//       {
+//          tree_[name] = eventsDir.make<TTree>(name.c_str(),fullname.c_str());
+//          pileupinfo_ = pPileupInfo( new PileupInfo(collection, tree_[name]) );
+//          pileupinfo_ -> Branches();
+// 
+//       }
          
 
 

--- a/Analysis/Ntuplizer/src/EventInfo.cc
+++ b/Analysis/Ntuplizer/src/EventInfo.cc
@@ -49,10 +49,6 @@ EventInfo::EventInfo(edm::Service<TFileService> & fs)
    tree_->Branch("bx"   , &bx_   , "bx/I");
    tree_->Branch("orbit", &orbit_, "orbit/I");
 
-      
-   tree_->Branch("nPileup"     , &n_pu_     , "nPileup/I");
-   tree_->Branch("nTruePileup" , &n_true_pu_, "nTruePileup/F");
-   
    do_pu_ = false;
    
    
@@ -70,10 +66,6 @@ EventInfo::EventInfo(TFileDirectory & dir)
    tree_->Branch("bx"   , &bx_   , "bx/I");
    tree_->Branch("orbit", &orbit_, "orbit/I");
 
-      
-   tree_->Branch("nPileup"     , &n_pu_     , "nPileup/I");
-   tree_->Branch("nTruePileup" , &n_true_pu_, "nTruePileup/F");
-   
    do_pu_ = false;
    
 }
@@ -133,6 +125,10 @@ void EventInfo::PileupInfo(const edm::InputTag& tag)
    do_pu_ = true;
    
    puInfo_ = tag;
+      
+   tree_->Branch("nPileup"     , &n_pu_     , "nPileup/I");
+   tree_->Branch("nTruePileup" , &n_true_pu_, "nTruePileup/F");
+   
 }
 
 void EventInfo::ReadPileupInfo(const edm::Event& event)

--- a/Analysis/Ntuplizer/src/EventInfo.cc
+++ b/Analysis/Ntuplizer/src/EventInfo.cc
@@ -19,6 +19,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
  
 #include "Analysis/Ntuplizer/interface/EventInfo.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
 
 //
@@ -47,6 +48,12 @@ EventInfo::EventInfo(edm::Service<TFileService> & fs)
    tree_->Branch("lumisection" , &lumi_ , "lumisection/I");
    tree_->Branch("bx"   , &bx_   , "bx/I");
    tree_->Branch("orbit", &orbit_, "orbit/I");
+
+      
+   tree_->Branch("nPileup"     , &n_pu_     , "nPileup/I");
+   tree_->Branch("nTruePileup" , &n_true_pu_, "nTruePileup/F");
+   
+   do_pu_ = false;
    
    
 }
@@ -62,7 +69,12 @@ EventInfo::EventInfo(TFileDirectory & dir)
    tree_->Branch("lumisection" , &lumi_ , "lumisection/I");
    tree_->Branch("bx"   , &bx_   , "bx/I");
    tree_->Branch("orbit", &orbit_, "orbit/I");
+
+      
+   tree_->Branch("nPileup"     , &n_pu_     , "nPileup/I");
+   tree_->Branch("nTruePileup" , &n_true_pu_, "nTruePileup/F");
    
+   do_pu_ = false;
    
 }
 
@@ -90,7 +102,16 @@ void EventInfo::Fill(const edm::Event& event)
    orbit_ = evt.orbitNumber();
    bx_    = evt.bunchCrossing();
    
-   
+   if ( do_pu_ )
+   {
+      ReadPileupInfo(event);
+   }
+   else
+   {
+      n_pu_ = -1;
+      n_true_pu_ = -1;
+   }
+      
    tree_ -> Fill();
 
    
@@ -105,5 +126,30 @@ void EventInfo::Init()
 TTree * EventInfo::Tree()
 {
    return tree_;
+}
+
+void EventInfo::PileupInfo(const edm::InputTag& tag)
+{
+   do_pu_ = true;
+   
+   puInfo_ = tag;
+}
+
+void EventInfo::ReadPileupInfo(const edm::Event& event)
+{
+   using namespace edm;
+   
+   // 
+   edm::Handle<std::vector<PileupSummaryInfo> > handler;
+   event.getByLabel(puInfo_, handler);
+
+   std::vector<PileupSummaryInfo> pileup_infos = *(handler.product());
+   
+// Take the first entry - should be enough
+   PileupSummaryInfo pileup_info = pileup_infos.at(0);
+   n_true_pu_ = pileup_info.getTrueNumInteractions();
+   n_pu_      = pileup_info.getPU_NumInteractions();
+    
+   
 }
 

--- a/Analysis/Tools/bin/AnalysisEventInfo.cc
+++ b/Analysis/Tools/bin/AnalysisEventInfo.cc
@@ -1,0 +1,46 @@
+#include <string>
+#include <iostream>
+#include <vector>
+
+#include "TFile.h" 
+#include "TFileCollection.h"
+#include "TChain.h"
+#include "TH1.h" 
+
+#include "Analysis/Tools/interface/Analysis.h"
+
+using namespace std;
+using namespace analysis;
+using namespace analysis::tools;
+
+
+// =============================================================================================   
+int main(int argc, char * argv[])
+{
+   TH1::SetDefaultSumw2();  // proper treatment of errors when scaling histograms
+   
+   // Input files list
+   std::string inputList = "rootFileList.txt";
+   Analysis analysis(inputList);
+   
+   
+   // Analysis of events
+   std::cout << "This analysis has " << analysis.size() << " events" << std::endl;
+   for ( int i = 0 ; i < analysis.size() ; ++i )
+   {
+      analysis.event(i);
+      
+      std::cout << "++++++    ENTRY  " << i;
+      std::cout << ", Run = " << analysis.run();
+      std::cout << ", Event = " << analysis.event();
+      std::cout << ", LumiSection = " << analysis.lumiSection();
+      std::cout << ", nPileup = " << analysis.nPileup();
+      std::cout << ", nTruePileup = " << analysis.nTruePileup();
+      std::cout << std::endl;
+      
+      
+   }
+   
+//    
+}
+

--- a/Analysis/Tools/bin/BuildFile.xml
+++ b/Analysis/Tools/bin/BuildFile.xml
@@ -6,8 +6,6 @@
 <use name="boost" />
 <use name="Analysis/Tools" />
 
-<!--
-<bin   name="SimpleAnalysis" file="SimpleAnalysis.cc">
+<bin   name="AnalysisEventInfo" file="AnalysisEventInfo.cc">
 <flags   LDFLAGS="-lCore -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -lz -pthread -lm -ldl -rdynamic"/>
 </bin>
--->

--- a/Analysis/Tools/interface/Analysis.h
+++ b/Analysis/Tools/interface/Analysis.h
@@ -59,6 +59,9 @@ namespace analysis {
             int  run();
             int  lumiSection();
             bool isMC();
+            
+            int   nPileup();
+            float nTruePileup();
 
             // Trees
             template<class Object>
@@ -129,6 +132,9 @@ namespace analysis {
             int run_;
             int lumi_;
             bool is_mc_;
+            
+            int n_pu_;
+            float n_true_pu_;
 
             int nevents_;
 
@@ -263,13 +269,15 @@ namespace analysis {
       
 // ========================================================
 
-      inline int  Analysis::numberEvents() { return nevents_; }
-      inline int  Analysis::size()         { return nevents_; }
-      inline int  Analysis::event()        { return event_; }
-      inline int  Analysis::run()          { return run_  ; }
-      inline int  Analysis::lumiSection()  { return lumi_ ; }
-      inline bool Analysis::isMC()         { return is_mc_ ; }
+      inline int   Analysis::numberEvents() { return nevents_;   }
+      inline int   Analysis::size()         { return nevents_;   }
+      inline int   Analysis::event()        { return event_;     }
+      inline int   Analysis::run()          { return run_  ;     }
+      inline int   Analysis::lumiSection()  { return lumi_ ;     }
+      inline bool  Analysis::isMC()         { return is_mc_ ;    }
       
+      inline int   Analysis::nPileup()      { return n_pu_;      }
+      inline float Analysis::nTruePileup()  { return n_true_pu_; }
       
 //      inline std::string Analysis::getGenParticleCollection() { return genParticleCollection_; }
 

--- a/Analysis/Tools/src/Analysis.cc
+++ b/Analysis/Tools/src/Analysis.cc
@@ -42,6 +42,8 @@ Analysis::Analysis(const std::string & inputFilelist, const std::string & evtinf
    t_event_ -> SetBranchAddress("event", &event_);
    t_event_ -> SetBranchAddress("run", &run_);
    t_event_ -> SetBranchAddress("lumisection", &lumi_);
+   t_event_ -> SetBranchAddress("nPileup", &n_pu_);
+   t_event_ -> SetBranchAddress("nTruePileup", &n_true_pu_);
 
    nevents_ = t_event_ -> GetEntries();
 

--- a/Analysis/Tools/src/Analysis.cc
+++ b/Analysis/Tools/src/Analysis.cc
@@ -39,11 +39,23 @@ Analysis::Analysis(const std::string & inputFilelist, const std::string & evtinf
    // event info (must be in the tree always)
    t_event_ = new TChain(evtinfo.c_str());
    t_event_ -> AddFileInfoList(fileList_);
+   
+   std::vector<std::string> branches;
+   TObjArray * treeBranches = t_event_->GetListOfBranches();
+   for ( int i = 0 ; i < treeBranches->GetEntries() ; ++i )
+      branches.push_back(treeBranches->At(i)->GetName());
+   
    t_event_ -> SetBranchAddress("event", &event_);
    t_event_ -> SetBranchAddress("run", &run_);
    t_event_ -> SetBranchAddress("lumisection", &lumi_);
-   t_event_ -> SetBranchAddress("nPileup", &n_pu_);
-   t_event_ -> SetBranchAddress("nTruePileup", &n_true_pu_);
+   
+   // For backward compatibility
+   std::vector<std::string>::iterator it;
+   it = std::find(branches.begin(),branches.end(),"nPileup");      if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &n_pu_);
+   it = std::find(branches.begin(),branches.end(),"nTruePileup");  if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &n_true_pu_);
+   
+//   t_event_ -> SetBranchAddress("nPileup", &n_pu_);
+//   t_event_ -> SetBranchAddress("nTruePileup", &n_true_pu_);
 
    nevents_ = t_event_ -> GetEntries();
 
@@ -71,6 +83,10 @@ Analysis::~Analysis()
 // ------------ method called for each event  ------------
 void Analysis::event(const int & event, const bool & addCollections)
 {
+   // Initialisation for backward compatibility
+   n_pu_ = -1;
+   n_true_pu_ = -1;
+   
    t_event_ -> GetEntry(event);
    if ( !addCollections) return;
    


### PR DESCRIPTION
This pull request essentially contains a modification on how the pile up information is stored. Instead of having a standalone tree to store the two main numbers of the PileupSummaryInfo, those two numbers are now stored in the EventInfo when such information is available.
The methods Analysis::nPileup() and Analysis::nTruePileup() return the corresponding values from the ntuple.
