### PR TITLE
Working with more than one btag algorithm in the Analysis

### DIFF
--- a/Analysis/Tools/bin/AnalysisJetsFlavour.cc
+++ b/Analysis/Tools/bin/AnalysisJetsFlavour.cc
@@ -24,14 +24,13 @@ int main(int argc, char * argv[])
    Analysis analysis(inputList);
    
    // Physics Objects Collections
-   analysis.addTree<Jet> ("Jets","MssmHbb/Events/slimmedJetsPuppi");
+   analysis.addTree<Jet> ("Jets","MssmHbb/Events/slimmedJetsReapplyJEC");
    analysis.addTree<GenParticle> ("GenParticles","MssmHbb/Events/prunedGenParticles");
 
    
    // Analysis of events
    std::cout << "This analysis has " << analysis.size() << " events" << std::endl;
    for ( int i = 0 ; i < analysis.size() ; ++i )
-//   for ( int i = 0 ; i < 1000 ; ++i )
    {
 //      std::cout << "++++++    ENTRY  " << i;
 //      std::cout << std::endl;
@@ -43,18 +42,18 @@ int main(int argc, char * argv[])
       
       // Jets
       auto jets = analysis.collection<Jet>("Jets");
-//       std::cout << "  #jets = " << jets->size() << ", particles = " << particles->size() << std::endl;
-//       std::cout << "oi" << std::endl;
-      jets->associatePartons(particles,0.3,10);
-//       std::cout << "oioi" << std::endl;
+      jets->associatePartons(particles,0.4,1);
+      jets->btagAlgo("btag_csvmva");
       
       for ( int j = 0 ; j < jets->size() ; ++j )
       {
          Jet jet = jets->at(j);
+         if ( jet.pt() < 30 ) continue;
+//         std::cout << jet.btag() << "  " << jet.btag("btag_csvivf") << " pt = " <<  jet.pt() << std::endl;
          if ( ( jet.extendedFlavour() == "cc" || jet.extendedFlavour() == "bb" ) && jets->size() > 4 )
          {
 //            std::cout << analysis.event() << "  " << analysis.lumiSection() << std::endl;
-//            std::cout << "Jet # " << j << " with flavour = " << jet.flavour() << " and extended flavour = " << jet.extendedFlavour() << "  btag = " << jet.btag() << std::endl;
+//            std::cout << "Jet # " << j << " with flavour = " << jet.flavour() << " and extended flavour = " << jet.extendedFlavour() << "  btag = " << jet.btag("btag_csvivf") << ", " << jet.btag("btag_csvmva") << std::endl;
          }
       }
       

--- a/Analysis/Tools/interface/Collection.h
+++ b/Analysis/Tools/interface/Collection.h
@@ -59,7 +59,7 @@ namespace analysis {
            std::string name() const;
            
            void associatePartons(const std::shared_ptr<Collection<GenParticle> > & , const float & deltaR = 0.4, const float & ptMin = 1., const bool & pythia8 = true);
-           
+           void btagAlgo(const std::string &);           
             // ----------member data ---------------------------
          protected:
                

--- a/Analysis/Tools/interface/Jet.h
+++ b/Analysis/Tools/interface/Jet.h
@@ -44,6 +44,8 @@ namespace analysis {
             // Gets
             /// returns the btag value of btag_csvivf
             float btag()                        const;
+            /// returns the btag value of algorithm
+            float btag(const std::string & )    const;
             /// returns the flavour with the Hadron definition (=0 for data)
             int   flavour()                     const;
             /// returns the flavour given a definition (=0 for data)
@@ -64,6 +66,10 @@ namespace analysis {
             // Sets
             /// sets the btag value
             void  btag(const float &);
+            /// sets the btag value for difference algorithms
+            void  btag(const std::string &, const float &);
+            /// sets the default btag algo
+            void  btagAlgo(const std::string & );
             /// sets flavour
             void  flavour(const int &);
             /// sets flavour for a given definition
@@ -99,6 +105,10 @@ namespace analysis {
             //
             /// btag value 
             float btag_ ;
+            /// btag value for each algo
+            std::map<std::string, float> btags_ ;
+            /// default btag algo
+            std::string btagAlgo_;
             /// map of flavour to a given definition
             std::map<std::string, int> flavour_;
             /// flavours inside the jet

--- a/Analysis/Tools/interface/PhysicsObjectTree.h
+++ b/Analysis/Tools/interface/PhysicsObjectTree.h
@@ -67,6 +67,8 @@ namespace analysis {
          protected:
             // PatJets
             float btag_    [max_];
+            float btags_[15][max_];
+            std::map<std::string, float*> mbtag_;
             int   flavour_ [max_];
             int   hadrflavour_ [max_];
             int   partflavour_ [max_];

--- a/Analysis/Tools/src/Collection.cc
+++ b/Analysis/Tools/src/Collection.cc
@@ -35,6 +35,7 @@ namespace analysis {
       template <> void Collection<Vertex>::matchTo( const Collection<TriggerObject> & collection, const float & deltaR );
       template <> void Collection<Vertex>::matchTo( const std::shared_ptr<Collection<TriggerObject> > collection, const float & deltaR );
       template <> void Collection<Jet>::associatePartons( const std::shared_ptr<Collection<GenParticle> > & particles, const float & deltaR, const float & ptMin, const bool & pythia8  );
+      template <> void Collection<Jet>::btagAlgo( const std::string & algo );
    }
 }
 //
@@ -96,6 +97,17 @@ std::vector< std::shared_ptr<Object> >  Collection<Object>::vector()
    }
    return objects;
 }
+template <class Object>
+void Collection<Object>::btagAlgo(const std::string & algo  )
+{
+}
+template <>
+void Collection<Jet>::btagAlgo(const std::string & algo  )
+{
+   for ( auto & jet : objects_ )
+      jet.btagAlgo(algo);
+}
+
 template <class Object>
 void Collection<Object>::associatePartons(const std::shared_ptr<Collection<GenParticle> > & particles, const float & deltaR, const float & ptMin, const bool & pythia8  )
 {

--- a/Analysis/Tools/src/Jet.cc
+++ b/Analysis/Tools/src/Jet.cc
@@ -34,10 +34,12 @@ using namespace analysis::tools;
 Jet::Jet() : Candidate() 
 {
    extendedFlavour_ = "?";
+   btagAlgo_ = "btag_csvivf";
 }
 Jet::Jet(const float & pt, const float & eta, const float & phi, const float & e) : Candidate(pt,eta,phi,e,0.) 
 {
    extendedFlavour_ = "?";
+   btagAlgo_ = "btag_csvivf";
 }
 Jet::~Jet()
 {
@@ -50,18 +52,21 @@ Jet::~Jet()
 // member functions
 //
 // Gets
-float Jet::btag()                                  const { return btag_;                   }                   
+float Jet::btag()                                  const { return btags_.at(btagAlgo_);    }                   
+float Jet::btag(const std::string & algo)          const { return btags_.at(algo);         }                   
 int   Jet::flavour()                               const { return flavour_.at("Hadron");   }                   
 int   Jet::flavour(const std::string & definition) const { return flavour_.at(definition); }                   
 bool  Jet::idLoose()                               const { return idloose_;                }                   
 bool  Jet::idTight()                               const { return idtight_;                }         
 float Jet::jecUncert()                             const { return jecUnc_;                 }                   
 std::vector<int> Jet::flavours()                   const { return flavours_;               }
-std::vector< std::shared_ptr<GenParticle> > Jet::partons() const { return partons_;        }
+std::vector< std::shared_ptr<GenParticle> >\
+      Jet::partons()                               const { return partons_;        }
 std::string Jet::extendedFlavour()                 const { return extendedFlavour_;        }
 
 // Sets                                                             
 void Jet::btag     (const float & btag)                               { btag_    = btag; } 
+void Jet::btag     (const std::string & algo, const float & btag)     { btags_[algo]  = btag; } 
 void Jet::flavour  (const int   & flav)                               { flavour_["Hadron"] = flav; } 
 void Jet::flavour  (const std::string & definition, const int & flav) { flavour_[definition] = flav; } 
 void Jet::idLoose  (const bool  & loos)                               { idloose_ = loos; } 
@@ -69,7 +74,7 @@ void Jet::idTight  (const bool  & tigh)                               { idtight_
 void Jet::jecUncert(const float & ju)                                 { jecUnc_  = ju; } 
 void Jet::addParton(const std::shared_ptr<GenParticle> & parton)      { partons_.push_back(parton);
                                                                         flavours_.push_back(parton->pdgId());  }
-                                                                        
+void Jet::btagAlgo (const std::string & algo )                        { btagAlgo_ = algo; }                                                                        
                                                                         
 int Jet::removeParton(const int & i)
 {

--- a/Analysis/Tools/src/PhysicsObjectTree.cc
+++ b/Analysis/Tools/src/PhysicsObjectTree.cc
@@ -72,7 +72,23 @@ Collection<Candidate>  PhysicsObjectTree<Candidate>::collection()
 // Constructors and destructor
 PhysicsObjectTree<Jet>::PhysicsObjectTree(TChain * tree, const std::string & name) : PhysicsObjectTreeBase<Jet>(tree, name)
 {
-   tree_  -> SetBranchAddress( "btag_csvivf", btag_    );
+//   tree_  -> SetBranchAddress( "btag_csvivf", btag_    );
+   int algos = 0;
+   for ( auto & branch : branches_ )
+   {
+      std::size_t found = branch.find("btag_");
+      if (found!=std::string::npos)
+      {
+         mbtag_[branch] = btags_[algos];
+         ++algos;
+         tree_  -> SetBranchAddress( branch.c_str(), mbtag_[branch]);
+      }
+   }
+//    std::vector<std::string>::iterator it;
+//    it = std::find(branches_.begin(),branches_.end(),"btag_");
+//    if ( it != branches_.end() )
+//       std::cout << *it << std::endl;
+   
    tree_  -> SetBranchAddress( "flavour"        , flavour_ );
    tree_  -> SetBranchAddress( "hadronFlavour"  , hadrflavour_ );
    tree_  -> SetBranchAddress( "partonFlavour"  , partflavour_ );
@@ -99,6 +115,8 @@ Collection<Jet>  PhysicsObjectTree<Jet>::collection()
    {
       Jet jet(pt_[i], eta_[i], phi_[i], e_[i]);
       jet.btag(btag_[i]);
+      for ( auto & b : mbtag_ )
+         jet.btag(b.first,b.second[i]);
       jet.flavour(flavour_[i]);
       jet.flavour("Hadron",hadrflavour_[i]);
       jet.flavour("Parton",partflavour_[i]);


### PR DESCRIPTION
If the ntuple contains btagging from several algorithms the user can choose which one interests. Default is "btag_csvivf".
See [example](https://raw.githubusercontent.com/robervalwalsh/analysis/develop/Analysis/Tools/bin/AnalysisJetsFlavour.cc) on how to set default algo and read the btag for different algos.
