### PR TITLE
GenEventInfoProduct information

### DIFF
--- a/Analysis/Ntuplizer/interface/EventInfo.h
+++ b/Analysis/Ntuplizer/interface/EventInfo.h
@@ -51,7 +51,9 @@ namespace analysis {
             void Fill(const edm::Event&);
             void Init();
             void PileupInfo(const edm::InputTag&);
+            void GenEventInfo(const edm::InputTag&);
             void ReadPileupInfo(const edm::Event&);
+            void ReadGenEventInfo(const edm::Event&);
             TTree * Tree();
       
          private:
@@ -72,6 +74,17 @@ namespace analysis {
             bool do_pu_;
             int n_pu_;
             float n_true_pu_;
+            
+            // GenEventInfo
+            edm::InputTag genInfo_;
+            bool do_gen_;
+            double genWeight_;
+            double genScale_;
+            int    pdfid1_;
+            int    pdfid2_;
+            double pdfx1_;
+            double pdfx2_;
+            
             
       };
    }

--- a/Analysis/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Analysis/Ntuplizer/plugins/Ntuplizer.cc
@@ -76,6 +76,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 
 #include "Analysis/Ntuplizer/interface/EventFilter.h"
@@ -181,6 +182,7 @@ class Ntuplizer : public edm::EDAnalyzer {
       bool do_genparticles_;
       bool do_jetstags_;
       bool do_pileupinfo_;
+      bool do_geneventinfo_;
       bool do_triggeraccepts_;
       bool do_primaryvertices_;
       bool do_eventfilter_;
@@ -221,6 +223,7 @@ class Ntuplizer : public edm::EDAnalyzer {
       edm::InputTag genRunInfo_;
       
       edm::InputTag pileupInfo_;
+      edm::InputTag genEventInfo_;
      
       edm::EDGetTokenT<GenFilterInfo> genFilterInfoToken_;      
       edm::EDGetTokenT<edm::MergeableCounter> totalEventsToken_;      
@@ -228,6 +231,7 @@ class Ntuplizer : public edm::EDAnalyzer {
       edm::EDGetTokenT<GenRunInfoProduct> genRunInfoToken_;
            
       edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupInfoToken_;      
+      edm::EDGetTokenT<GenEventInfoProduct> genEventInfoToken_;      
       
       InputTags eventCounters_;
       
@@ -329,7 +333,8 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& config) //:   // initialization of
       if ( inputTag == "FilteredEvents" ) { filteredEventsToken_ = consumes<edm::MergeableCounter,edm::InLumi>(collection); filteredEvents_  = collection;}
       if ( inputTag == "GenRunInfo" )     { genRunInfoToken_     = consumes<GenRunInfoProduct,edm::InRun>(collection);      genRunInfo_      = collection;}
 
-      if ( inputTag == "PileupInfo" )     { pileupInfoToken_     = consumes<std::vector<PileupSummaryInfo> >(collection);                 pileupInfo_      = collection;}
+      if ( inputTag == "PileupInfo" )     { pileupInfoToken_     = consumes<std::vector<PileupSummaryInfo> >(collection);   pileupInfo_      = collection;}
+      if ( inputTag == "GenEventInfo" )   { genEventInfoToken_   = consumes<GenEventInfoProduct>(collection);               genEventInfo_    = collection;}
  
    }
 
@@ -435,6 +440,7 @@ void
 Ntuplizer::beginJob()
 {
    do_pileupinfo_       = config_.exists("PileupInfo") && is_mc_;
+   do_geneventinfo_     = config_.exists("GenEventInfo") && is_mc_;
    do_l1jets_           = config_.exists("L1ExtraJets");
    do_l1muons_          = config_.exists("L1ExtraMuons");
    do_calojets_         = config_.exists("CaloJets");
@@ -523,6 +529,8 @@ Ntuplizer::beginJob()
    eventinfo_ = pEventInfo (new EventInfo(eventsDir));
    if ( do_pileupinfo_ )
       eventinfo_ -> PileupInfo(config_.getParameter<edm::InputTag>("PileupInfo"));
+   if ( do_geneventinfo_ )
+      eventinfo_ -> GenEventInfo(config_.getParameter<edm::InputTag>("GenEventInfo"));
    
     // Metadata 
    metadata_ = pMetadata (new Metadata(fs,is_mc_));

--- a/Analysis/Ntuplizer/test/ntuplizer_mc_76x.py
+++ b/Analysis/Ntuplizer/test/ntuplizer_mc_76x.py
@@ -46,6 +46,7 @@ process.MssmHbb     = cms.EDAnalyzer("Ntuplizer",
     ## Monte Carlo only
     GenFilterInfo   = cms.InputTag("genFilterEfficiencyProducer"),
     GenRunInfo      = cms.InputTag("generator"),
+    GenEventInfo    = cms.InputTag("generator"),
     GenJets         = cms.VInputTag(cms.InputTag("slimmedGenJets")),
     GenParticles    = cms.VInputTag(cms.InputTag("prunedGenParticles")),
     PileupInfo      = cms.InputTag("slimmedAddPileupInfo"),

--- a/Analysis/Ntuplizer/test/ntuplizer_mc_76x_expert.py
+++ b/Analysis/Ntuplizer/test/ntuplizer_mc_76x_expert.py
@@ -103,6 +103,7 @@ process.MssmHbb     = cms.EDAnalyzer("Ntuplizer",
     ## Monte Carlo only
     GenFilterInfo   = cms.InputTag("genFilterEfficiencyProducer"),
     GenRunInfo      = cms.InputTag("generator"),
+    GenEventInfo    = cms.InputTag("generator"),
     GenJets         = cms.VInputTag(cms.InputTag("slimmedGenJets")),
     GenParticles    = cms.VInputTag(cms.InputTag("prunedGenParticles")),
     PileupInfo      = cms.InputTag("slimmedAddPileupInfo"),

--- a/Analysis/Tools/bin/AnalysisEventInfo.cc
+++ b/Analysis/Tools/bin/AnalysisEventInfo.cc
@@ -26,18 +26,31 @@ int main(int argc, char * argv[])
    
    // Analysis of events
    std::cout << "This analysis has " << analysis.size() << " events" << std::endl;
+      std::cout << "Printing information from first 5 entries... \n\n";
+            
    for ( int i = 0 ; i < analysis.size() ; ++i )
    {
       analysis.event(i);
       
-      std::cout << "++++++    ENTRY  " << i;
-      std::cout << ", Run = " << analysis.run();
-      std::cout << ", Event = " << analysis.event();
-      std::cout << ", LumiSection = " << analysis.lumiSection();
-      std::cout << ", nPileup = " << analysis.nPileup();
-      std::cout << ", nTruePileup = " << analysis.nTruePileup();
-      std::cout << std::endl;
-      
+      if ( i < 5 ) 
+      {
+         std::cout << "++++++    ENTRY  " << i;
+         std::cout << ", Run = " << analysis.run();
+         std::cout << ", Event = " << analysis.event();
+         std::cout << ", LumiSection = " << analysis.lumiSection();
+         std::cout << ", nPileup = " << analysis.nPileup();
+         std::cout << ", nTruePileup = " << analysis.nTruePileup();
+         std::cout << std::endl;
+         std::cout << "                  ";
+         std::cout << "  Gen Weight = " << analysis.genWeight();
+         std::cout << ", Gen Scale = " << analysis.genScale();
+         std::cout << ", PDF id 1 = " << analysis.pdf().id.first;
+         std::cout << ", PDF id 2 = " << analysis.pdf().id.second;
+         std::cout << ", PDF x 1  = " << analysis.pdf().x.first;
+         std::cout << ", PDF x 2  = " << analysis.pdf().x.second;
+         std::cout << "\n" << std::endl;
+         
+      }            
       
    }
    

--- a/Analysis/Tools/bin/rootFileList.txt
+++ b/Analysis/Tools/bin/rootFileList.txt
@@ -1,1 +1,1 @@
-/nfs/dust/cms/user/walsh/tmp/test_mc_qcd1000-1400.root
+/nfs/dust/cms/user/walsh/tmp/test_mc_hbbM300.root

--- a/Analysis/Tools/interface/Analysis.h
+++ b/Analysis/Tools/interface/Analysis.h
@@ -60,8 +60,15 @@ namespace analysis {
             int  lumiSection();
             bool isMC();
             
+            // PileupInfo
             int   nPileup();
             float nTruePileup();
+            
+            // GenEventInfo
+            double genWeight();
+            double genScale();
+            PDF    pdf();
+            
 
             // Trees
             template<class Object>
@@ -135,6 +142,10 @@ namespace analysis {
             
             int n_pu_;
             float n_true_pu_;
+            
+            double genWeight_;
+            double genScale_;
+            PDF    pdf_;
 
             int nevents_;
 
@@ -278,6 +289,10 @@ namespace analysis {
       
       inline int   Analysis::nPileup()      { return n_pu_;      }
       inline float Analysis::nTruePileup()  { return n_true_pu_; }
+      
+      inline double Analysis::genWeight()   { return genWeight_; }
+      inline double Analysis::genScale()    { return genScale_;  }
+      inline PDF    Analysis::pdf()         { return pdf_;       }
       
 //      inline std::string Analysis::getGenParticleCollection() { return genParticleCollection_; }
 

--- a/Analysis/Tools/interface/Utils.h
+++ b/Analysis/Tools/interface/Utils.h
@@ -11,6 +11,11 @@ namespace analysis {
          float efficiency;
       };
       
+      struct PDF
+      {
+         std::pair<int,int> id;
+         std::pair<double,double> x;
+      };
    }
 }
 

--- a/Analysis/Tools/src/Analysis.cc
+++ b/Analysis/Tools/src/Analysis.cc
@@ -54,6 +54,14 @@ Analysis::Analysis(const std::string & inputFilelist, const std::string & evtinf
    it = std::find(branches.begin(),branches.end(),"nPileup");      if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &n_pu_);
    it = std::find(branches.begin(),branches.end(),"nTruePileup");  if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &n_true_pu_);
    
+   it = std::find(branches.begin(),branches.end(),"genWeight");    if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &genWeight_);
+   it = std::find(branches.begin(),branches.end(),"genScale");     if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &genScale_);
+   it = std::find(branches.begin(),branches.end(),"pdfid1");       if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &pdf_.id.first);
+   it = std::find(branches.begin(),branches.end(),"pdfid2");       if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &pdf_.id.second);
+   it = std::find(branches.begin(),branches.end(),"pdfx1");        if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &pdf_.x.first);
+   it = std::find(branches.begin(),branches.end(),"pdfx2");        if ( it != branches.end() ) t_event_  -> SetBranchAddress( (*it).c_str(), &pdf_.x.second);
+   
+   
 //   t_event_ -> SetBranchAddress("nPileup", &n_pu_);
 //   t_event_ -> SetBranchAddress("nTruePileup", &n_true_pu_);
 
@@ -86,6 +94,13 @@ void Analysis::event(const int & event, const bool & addCollections)
    // Initialisation for backward compatibility
    n_pu_ = -1;
    n_true_pu_ = -1;
+   
+   genWeight_ = -1.;
+   genScale_  = -1.;
+   pdf_.id.first  = 0;
+   pdf_.id.second = 0;
+   pdf_.x.first  = -1.;
+   pdf_.x.second = -1.;
    
    t_event_ -> GetEntry(event);
    if ( !addCollections) return;


### PR DESCRIPTION
Information from GenEventInfoProduct, such as scale, weight, pdf id and pdf x, were added to the ntuple in the EventInfo tree.
In the Analysis class this info is readout from the ntuple if available.
See example on how to retrieve the information in Analysis/Tools/bin/AnalysisEventInfo.cc
