### PR TITLE
Event filter info

### DIFF
--- a/Analysis/Ntuplizer/test/ntuplizer_mc_76x.py
+++ b/Analysis/Ntuplizer/test/ntuplizer_mc_76x.py
@@ -17,14 +17,30 @@ for pset in process.GlobalTag.toGet.value():
 process.GlobalTag.RefreshEachRun = cms.untracked.bool( False )
 process.GlobalTag.ReconnectEachRun = cms.untracked.bool( False )
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
-output_file = 'test_mc.root'
+output_file = '/nfs/dust/cms/user/walsh/tmp/test_mc_hbbM300_2.root'
 ## TFileService
 process.TFileService = cms.Service("TFileService",
 	fileName = cms.string(output_file)
 )
 
+## ============ TRIGGER FILTER =============== 
+## Enable below at cms.Path if needed 
+process.triggerSelection = cms.EDFilter( "TriggerResultsFilter",
+    triggerConditions = cms.vstring(
+                        'HLT_DoubleJetsC100_DoubleBTagCSV0p85_DoublePFJetsC160_v*',
+                        'HLT_DoubleJetsC100_DoubleBTagCSV0p9_DoublePFJetsC100MaxDeta1p6_v*',
+                        'HLT_DoubleJetsC112_DoubleBTagCSV0p85_DoublePFJetsC172_v*',
+                        'HLT_DoubleJetsC112_DoubleBTagCSV0p9_DoublePFJetsC112MaxDeta1p6_v*',
+    ),
+    hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+    l1tResults = cms.InputTag( "" ),
+    l1tIgnoreMask = cms.bool( False ),
+    l1techIgnorePrescales = cms.bool( False ),
+    daqPartitions = cms.uint32( 1 ),
+    throw = cms.bool( True )
+)
 
 ## ============ EVENT FILTER COUNTER ===============
 ## Filter counter (maybe more useful for MC)
@@ -110,6 +126,7 @@ process.MssmHbb     = cms.EDAnalyzer("Ntuplizer",
 
 process.p = cms.Path(
                       process.TotalEvents *
+#                      process.triggerSelection *   # use this carefully!!!
                       process.primaryVertexFilter *
                       process.FilteredEvents *
                       process.MssmHbb
@@ -120,7 +137,8 @@ readFiles = cms.untracked.vstring()
 secFiles = cms.untracked.vstring() 
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
-       '/store/mc/RunIIFall15MiniAODv2/SUSYGluGluToBBHToBB_M-300_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/PU25nsData2015v1Raw_76X_mcRun2_asymptotic_v12-v1/00000/0A91D2C2-12C6-E511-B7E7-90B11C050AD4.root',
+#       '/store/mc/RunIIFall15MiniAODv2/SUSYGluGluToBBHToBB_M-300_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/PU25nsData2015v1Raw_76X_mcRun2_asymptotic_v12-v1/00000/0A91D2C2-12C6-E511-B7E7-90B11C050AD4.root',
+       '/store/mc/RunIIFall15MiniAODv2/SUSYGluGluToBBHToBB_M-300_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/PU25nsData2015v1Raw_76X_mcRun2_asymptotic_v12-v1/00000/0C785886-08C6-E511-9748-90B11C2CB7A9.root',
 ] );
 
 

--- a/Analysis/Tools/bin/AnalysisMetadata.cc
+++ b/Analysis/Tools/bin/AnalysisMetadata.cc
@@ -1,0 +1,39 @@
+#include <string>
+#include <iostream>
+#include <vector>
+
+#include "TFile.h" 
+#include "TFileCollection.h"
+#include "TChain.h"
+#include "TH1.h" 
+
+#include "Analysis/Tools/interface/Analysis.h"
+
+using namespace std;
+using namespace analysis;
+using namespace analysis::tools;
+
+
+// =============================================================================================   
+int main(int argc, char * argv[])
+{
+   TH1::SetDefaultSumw2();  // proper treatment of errors when scaling histograms
+   
+   // Input files list
+   std::string inputList = "rootFileList.txt";
+   Analysis analysis(inputList);
+   
+   
+   // Analysis of events
+   std::cout << "This analysis has " << analysis.size() << " events" << std::endl;
+   std::cout << "Printing EventFilter info from Metadata \n\n";
+            
+   FilterResults evtFilter = analysis.eventFilter("MssmHbb/Metadata/EventFilter");    
+   
+   std::cout << "Total    events   =  " << evtFilter.total      << std::endl;
+   std::cout << "Filtered events   =  " << evtFilter.filtered   << std::endl;
+   std::cout << "Filter efficiency =  " << evtFilter.efficiency << std::endl;
+     
+//    
+}
+

--- a/Analysis/Tools/bin/BuildFile.xml
+++ b/Analysis/Tools/bin/BuildFile.xml
@@ -17,3 +17,7 @@
 <bin   name="AnalysisJetsFlavour" file="AnalysisJetsFlavour.cc">
 <flags   LDFLAGS="-lCore -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -lz -pthread -lm -ldl -rdynamic"/>
 </bin>
+
+<bin   name="AnalysisMetadata" file="AnalysisMetadata.cc">
+<flags   LDFLAGS="-lCore -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lTree -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -lz -pthread -lm -ldl -rdynamic"/>
+</bin>

--- a/Analysis/Tools/bin/rootFileList.txt
+++ b/Analysis/Tools/bin/rootFileList.txt
@@ -1,1 +1,2 @@
-/nfs/dust/cms/user/walsh/tmp/test_mc_hbbM300.root
+/nfs/dust/cms/user/walsh/tmp/test_mc_hbbM300_1.root
+/nfs/dust/cms/user/walsh/tmp/test_mc_hbbM300_2.root

--- a/Analysis/Tools/interface/Analysis.h
+++ b/Analysis/Tools/interface/Analysis.h
@@ -109,6 +109,9 @@ namespace analysis {
             FilterResults generatorFilter(const std::string & path);
             void listGeneratorFilter();
             
+            // Event Filter
+            FilterResults eventFilter(const std::string & path);
+            
             // Matching to trigger objects
             template <class Object1, class Object2>
             void match(const std::string & collection, const std::string & match_collection, const float & deltaR = 0.5);
@@ -131,6 +134,7 @@ namespace analysis {
             std::map<std::string, bool> triggerResults_;
             std::map<int,std::vector<std::string> > goodLumi_;
             FilterResults genfilter_;
+            FilterResults evtfilter_;
             
             // default collections
             std::string defaultGenParticle_;
@@ -153,6 +157,7 @@ namespace analysis {
             void treeInit_(const std::string & unique_name, const std::string & path);
             TChain * t_xsection_;
             TChain * t_genfilter_;
+            TChain * t_evtfilter_;
             TChain * t_event_;
             TChain * t_triggerResults_;
 

--- a/Analysis/Tools/src/Analysis.cc
+++ b/Analysis/Tools/src/Analysis.cc
@@ -298,6 +298,36 @@ void Analysis::listGeneratorFilter()
 
 }
 
+FilterResults Analysis::eventFilter(const std::string & path)
+{
+   t_evtfilter_  = new TChain(path.c_str());
+   t_evtfilter_ -> AddFileInfoList(fileList_);
+
+   unsigned int ntotal;
+   unsigned int nfiltered;
+   unsigned int sumtotal = 0;
+   unsigned int sumfiltered = 0;
+
+   t_evtfilter_ -> SetBranchAddress("nEventsTotal", &ntotal);
+   t_evtfilter_ -> SetBranchAddress("nEventsFiltered", &nfiltered);
+
+   for ( int i = 0; i < t_evtfilter_->GetEntries(); ++i )
+   {
+      t_evtfilter_ -> GetEntry(i);
+      sumtotal += ntotal;
+      sumfiltered += nfiltered;
+   }
+
+
+   evtfilter_.total = sumtotal;
+   evtfilter_.filtered = sumfiltered;
+   evtfilter_.efficiency = float(sumfiltered)/sumtotal;
+
+   return evtfilter_;
+}
+
+
+
 void Analysis::processJsonFile(const std::string & fileName)
 {
 	std::string scriptName = "source $CMSSW_BASE/src/Analysis/Tools/interface/strip.sh ";


### PR DESCRIPTION
Analysis class can now retrieve the event filter information stored in the Metadata tree in the ntuple via method
FilterResults Analysis::eventFilter(const std::string & path)
